### PR TITLE
Potential fix for code scanning alert no. 2: DOM text reinterpreted as HTML

### DIFF
--- a/src/pages/PortfolioPage.jsx
+++ b/src/pages/PortfolioPage.jsx
@@ -279,7 +279,7 @@ const PortfolioPage = () => {
                     <a href={`https://instagram.com/sharer.php?u=${window.location.href}`} target="_blank" rel="noopener noreferrer">
                       <FaInstagram className="share-icon" />
                     </a>
-                    <a href={`https://twitter.com/intent/tweet?url=${window.location.href}&text=Check out this recipe: ${recipe.title}`} target="_blank" rel="noopener noreferrer">
+                    <a href={`https://twitter.com/intent/tweet?url=${window.location.href}&text=Check out this recipe: ${encodeURIComponent(recipe.title)}`} target="_blank" rel="noopener noreferrer">
                       <FaTwitter className="share-icon" />
                     </a>
                     <a href={`https://www.facebook.com/sharer/sharer.php?u=${window.location.href}`} target="_blank" rel="noopener noreferrer">


### PR DESCRIPTION
Potential fix for [https://github.com/techgirldiaries/RecipeNest/security/code-scanning/2](https://github.com/techgirldiaries/RecipeNest/security/code-scanning/2)

In general, when untrusted text is inserted into URLs as query parameters, it should be URL‑encoded first (for example, via `encodeURIComponent`) rather than concatenated raw. This ensures that meta‑characters (`&`, `?`, `"`, `<`, `>`, etc.) cannot break out of their intended context and that the generated URL is syntactically valid.

The best targeted fix here is to URL‑encode `recipe.title` before including it in the Twitter share URL. We can do this directly in the JSX on line 282 by wrapping `recipe.title` with `encodeURIComponent(...)`. Since `encodeURIComponent` is a built‑in global in browsers, no new imports are required, and functionality remains the same except that special characters in the tweet text will be correctly encoded.

Concretely, in `src/pages/PortfolioPage.jsx`, locate the `<a>` tag on line 282 that currently has:

```jsx
<a href={`https://twitter.com/intent/tweet?url=${window.location.href}&text=Check out this recipe: ${recipe.title}`} ...
```

and change only the interpolation of `recipe.title` to:

```jsx
<a href={`https://twitter.com/intent/tweet?url=${window.location.href}&text=Check out this recipe: ${encodeURIComponent(recipe.title)}`} ...
```

This keeps everything else intact and removes the tainted, unencoded text from the URL context. No additional methods, helper functions, or imports are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
